### PR TITLE
feat(IPVC-2268): added missing uta build steps

### DIFF
--- a/sbin/exonset-to-seqinfo
+++ b/sbin/exonset-to-seqinfo
@@ -32,7 +32,7 @@ def parse_args(argv):
                     required=True)
     ap.add_argument("--conf",
                     default=[
-                        pkg_resources.resource_filename("uta", "../etc/global.conf")]
+                        pkg_resources.resource_filename("uta", "../../etc/global.conf")]
                     )
 
     opts = ap.parse_args(argv)
@@ -50,9 +50,9 @@ if __name__ == "__main__":
 
     opts = parse_args(sys.argv[1:])
 
-    cf = ConfigParser.SafeConfigParser()
+    cf = ConfigParser.ConfigParser()
     for conf_fn in opts.conf:
-        cf.readfp(open(conf_fn))
+        cf.read_file(open(conf_fn))
         logger.info("loaded " + conf_fn)
 
     in_fn = opts.FILES[0]

--- a/sbin/ncbi_parse_genomic_gff.py
+++ b/sbin/ncbi_parse_genomic_gff.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """Write exonsets from NCBI GFF alignments, as obtained from
 ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions
 This service appeared in April 2015 and is due to update weekly.

--- a/src/uta/loading.py
+++ b/src/uta/loading.py
@@ -42,13 +42,13 @@ def align_exons(session, opts, cf):
 
     def _get_cursor(con):
         cur = con.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
-        cur.execute(text("set role {admin_role};".format(
-            admin_role=cf.get("uta", "admin_role"))))
-        cur.execute(text("set search_path = " + usam.schema_name))
+        cur.execute("set role {admin_role};".format(
+            admin_role=cf.get("uta", "admin_role")))
+        cur.execute("set search_path = " + usam.schema_name)
         return cur
 
     def align(s1, s2):
-        score, cigar = utaa.algorithms.needleman_wunsch_gotoh_align(s1.encode("ascii"),
+        score, cigar = utaa.align.algorithms.needleman_wunsch_gotoh_align(s1.encode("ascii"),
                                                                     s2.encode("ascii"),
                                                                     extended_cigar=True)
         tx_aseq, alt_aseq = utaa.algorithms.cigar_alignment(


### PR DESCRIPTION
This PR adds the following UTA build steps to the run-uta-build.sh script and contains a few bug fixes.

- Parse GBFF files
- Create seqinfo from exonset intermediate file
- load exonsets into UTA database

Steps still missing:

- load seqinfo: blocked by IPVC-2266
- align-exons: blocked by IPVC-??