### PR TITLE
feat(IPVC-2229): add utility to download from eutils

### DIFF
--- a/src/uta/exceptions.py
+++ b/src/uta/exceptions.py
@@ -17,6 +17,10 @@ class InvalidIntervalError(UTAError):
 class InvalidHGVSVariantError(UTAError):
     pass
 
+
+class EutilsDownloadError(Exception):
+    pass
+
 # <LICENSE>
 # Copyright 2014 UTA Contributors (https://bitbucket.org/biocommons/uta)
 ##

--- a/src/uta/tools/eutils.py
+++ b/src/uta/tools/eutils.py
@@ -1,9 +1,16 @@
+from enum import Enum
+
 import requests
 
 from uta import EutilsDownloadError
 
 
-def download_from_eutils(accession: str, file_format: str, output_file: str) -> None:
+class NcbiFileFormatEnum(str, Enum):
+    FASTA = "fasta"
+    GENBANK = "gb"
+
+
+def download_from_eutils(accession: str, file_format: NcbiFileFormatEnum, output_file: str) -> None:
     """
     Download a file from NCBI using the eutils endpoint.
     Args:
@@ -11,8 +18,6 @@ def download_from_eutils(accession: str, file_format: str, output_file: str) -> 
     - file_format: File format to download ("fasta" or "gb")
     - output_file: Path to the file where the downloaded content will be saved
     """
-    if file_format not in ["fasta", "gb"]:
-        raise ValueError("file_format must be either 'fasta' or 'gb'")
 
     base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
     params = {

--- a/src/uta/tools/eutils.py
+++ b/src/uta/tools/eutils.py
@@ -1,10 +1,6 @@
-import logging
-
 import requests
 
 from uta import EutilsDownloadError
-
-logger = logging.getLogger(__name__)
 
 
 def download_from_eutils(accession: str, file_format: str, output_file: str) -> None:

--- a/src/uta/tools/eutils.py
+++ b/src/uta/tools/eutils.py
@@ -1,0 +1,34 @@
+import logging
+
+import requests
+
+from uta import EutilsDownloadError
+
+logger = logging.getLogger(__name__)
+
+
+def download_from_eutils(accession: str, file_format: str, output_file: str) -> None:
+    """
+    Download a file from NCBI using the eutils endpoint.
+    Args:
+    - accession: NCBI accession ID
+    - file_format: File format to download ("fasta" or "gb")
+    - output_file: Path to the file where the downloaded content will be saved
+    """
+    if file_format not in ["fasta", "gb"]:
+        raise ValueError("file_format must be either 'fasta' or 'gb'")
+
+    base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    params = {
+        "db": "nuccore",
+        "id": accession,
+        "retmode": "text",
+        "rettype": file_format
+    }
+    response = requests.get(base_url, params=params)
+
+    if response.status_code == 200:
+        with open(output_file, 'w') as file:
+            file.write(response.text)
+    else:
+        raise EutilsDownloadError(f"Failed to download {file_format} file for {accession}. HTTP status code: {response.status_code}")

--- a/tests/test_uta_tools_eutils.py
+++ b/tests/test_uta_tools_eutils.py
@@ -1,0 +1,51 @@
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from uta import EutilsDownloadError
+from uta.tools.eutils import download_from_eutils
+
+
+class TestEutils(unittest.TestCase):
+    URL = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
+
+    def setUp(self):
+        self.output_file = 'test_output.fa'
+
+    def tearDown(self):
+        if os.path.exists(self.output_file):
+            os.remove(self.output_file)
+
+    @patch('requests.get')
+    def test_successful_download(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = 'file content'
+        mock_get.return_value = mock_response
+
+        download_from_eutils('accession', 'fasta', self.output_file)
+
+        mock_get.assert_called_once_with(
+            self.URL,
+            params={
+                'db': 'nuccore',
+                'id': 'accession',
+                'retmode': 'text',
+                'rettype': 'fasta'
+            }
+        )
+
+        with open(self.output_file, 'r') as file:
+            self.assertEqual(file.read(), 'file content')
+
+    @patch('requests.get')
+    def test_unsuccessful_download(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+        with self.assertRaises(EutilsDownloadError):
+            download_from_eutils('accession', 'fasta', self.output_file)
+
+    def test_invalid_file_format_raises(self):
+        with self.assertRaises(ValueError):
+            download_from_eutils('accession', 'invalid', self.output_file)

--- a/tests/test_uta_tools_eutils.py
+++ b/tests/test_uta_tools_eutils.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from uta import EutilsDownloadError
-from uta.tools.eutils import download_from_eutils
+from uta.tools.eutils import download_from_eutils, NcbiFileFormatEnum
 
 
 class TestEutils(unittest.TestCase):
@@ -23,7 +23,7 @@ class TestEutils(unittest.TestCase):
         mock_response.text = 'file content'
         mock_get.return_value = mock_response
 
-        download_from_eutils('accession', 'fasta', self.output_file)
+        download_from_eutils('accession', NcbiFileFormatEnum.FASTA, self.output_file)
 
         mock_get.assert_called_once_with(
             self.URL,
@@ -44,8 +44,4 @@ class TestEutils(unittest.TestCase):
         mock_response.status_code = 404
         mock_get.return_value = mock_response
         with self.assertRaises(EutilsDownloadError):
-            download_from_eutils('accession', 'fasta', self.output_file)
-
-    def test_invalid_file_format_raises(self):
-        with self.assertRaises(ValueError):
-            download_from_eutils('accession', 'invalid', self.output_file)
+            download_from_eutils('accession', NcbiFileFormatEnum.FASTA, self.output_file)


### PR DESCRIPTION
Description:
For the UTA build process we need to incorporate data for sequences that are not present in the NCBI FTP bulk downloads. Examples of this are NC_012920.1 (Mito genome reference) or older minor versions of RefSeq transcripts we need to support.

Acceptance Criteria:
* A method in UTA that can be called and passed a NCBI accession and request a fasta or gbff file.
* If eutils fetch fails, raise an error