### PR TITLE
feat(IPVC-2278): update uta-align

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,5 +341,5 @@ Run `sbin/uta-update`. Requires bash and docker.
 
 Example:
 ```
-sbin/uta-update $(pwd)/ncbi-data $(pwd)/seqrepo-data $(pwd) uta_20210129b 2024-02-20
+sbin/uta-update $(pwd)/ncbi-data $(pwd)/seqrepo-data $(pwd)/uta-build uta_20210129b 2024-02-20
 ```

--- a/README.md
+++ b/README.md
@@ -341,5 +341,5 @@ Run `sbin/uta-update`. Requires bash and docker.
 
 Example:
 ```
-sbin/uta-update $(pwd)/ncbi-data $(pwd)/seqrepo-data uta_20210129b 2021-01-29
+sbin/uta-update $(pwd)/ncbi-data $(pwd)/seqrepo-data $(pwd) uta_20210129b 2024-02-20
 ```

--- a/etc/scripts/run-uta-build.sh
+++ b/etc/scripts/run-uta-build.sh
@@ -20,9 +20,9 @@ fi
 
 # set local variables and create working directories
 loading_uta_v="uta_1_1"
-loading_dir="$working_dir/uta_build/loading"
-dumps_dir="$working_dir/uta_build/dumps"
-logs_dir="$working_dir/uta_build/logs"
+loading_dir="$working_dir/loading"
+dumps_dir="$working_dir/dumps"
+logs_dir="$working_dir/logs"
 for d in "$loading_dir" "$dumps_dir" "$logs_dir";
   do mkdir -p "$d"
 done

--- a/etc/scripts/run-uta-build.sh
+++ b/etc/scripts/run-uta-build.sh
@@ -20,9 +20,9 @@ fi
 
 # set local variables and create working directories
 loading_uta_v="uta_1_1"
-loading_dir="$working_dir/loading"
-dumps_dir="$working_dir/dumps"
-logs_dir="$working_dir/logs"
+loading_dir="$working_dir/uta_build/loading"
+dumps_dir="$working_dir/uta_build/dumps"
+logs_dir="$working_dir/uta_build/logs"
 for d in "$loading_dir" "$dumps_dir" "$logs_dir";
   do mkdir -p "$d"
 done
@@ -75,16 +75,10 @@ uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf load-exonset "$load
   tee "$logs_dir/load-exonsets.log"
 
 # align exons
-#uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf align-exons 2>&1 | tee "$logs_dir/align-exons.log"
-
+uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf align-exons 2>&1 | tee "$logs_dir/align-exons.log"
 
 ### run diff
 sbin/uta-diff "$source_uta_v" "$loading_uta_v"
-
-
-# exon alignments
-uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf load-exonset "$loading_dir/ncbi-gff.exonset.gz" 2>&1 | \
-  tee "$logs_dir/load-exonset.log"
 
 ### psql_dump
 pg_dump -U uta_admin -h localhost -d uta -t "$loading_uta_v.gene" | gzip -c > "$dumps_dir/uta.pgd.gz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   "pytz",
   "recordtype",
   "sqlalchemy",
-  "uta-align>=0.3.0a4",
+  "uta-align>=0.3",
 ]
 
 [project.optional-dependencies]

--- a/src/uta/loading.py
+++ b/src/uta/loading.py
@@ -13,12 +13,11 @@ from bioutils.coordinates import strand_pm_to_int, MINUS_STRAND
 from bioutils.digests import seq_md5
 from bioutils.sequences import reverse_complement
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import text
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import text
 import psycopg2.extras
 import six
-import uta_align as utaa
+from uta_align.align.algorithms import cigar_alignment, needleman_wunsch_gotoh_align
 
 from uta.lru_cache import lru_cache
 
@@ -48,10 +47,10 @@ def align_exons(session, opts, cf):
         return cur
 
     def align(s1, s2):
-        score, cigar = utaa.align.algorithms.needleman_wunsch_gotoh_align(s1.encode("ascii"),
-                                                                    s2.encode("ascii"),
-                                                                    extended_cigar=True)
-        tx_aseq, alt_aseq = utaa.algorithms.cigar_alignment(
+        score, cigar = needleman_wunsch_gotoh_align(s1.encode("ascii"),
+                                                    s2.encode("ascii"),
+                                                    extended_cigar=True)
+        tx_aseq, alt_aseq = cigar_alignment(
             tx_seq, alt_seq, cigar, hide_match=False)
         return tx_aseq.decode("ascii"), alt_aseq.decode("ascii"), cigar.to_string().decode("ascii")
 


### PR DESCRIPTION
Acceptance Criteria:
* uncomment “uta-align” command in run-uta-build.sh script and test



Note: `cigar_alignment` is not importable from `uta_align.algorthms`, it is only importable from `uta_align.align.algorithms`, hence that change in the code
```
In [1]: import uta_align

In [2]: uta_align.__version__
Out[2]: '0.3.0'

In [3]: from uta_align.algorithms import cigar_alignment
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[3], line 1
----> 1 from uta_align.algorithms import cigar_alignment

ModuleNotFoundError: No module named 'uta_align.algorithms'

In [4]: from uta_align.align.algorithms import cigar_alignment

In [5]:
```