### PR TITLE
IPVC-2379: add necessary NCBI input files to download config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   ncbi-download:
     image: uta-update
-    command: sbin/ncbi-download /ncbi-dir
+    command: sbin/ncbi-download etc/ncbi-files.txt /ncbi-dir
     volumes:
       - .:/opt/repos/uta
       - ${UTA_ETL_NCBI_DIR}:/ncbi-dir

--- a/etc/ncbi-files.txt
+++ b/etc/ncbi-files.txt
@@ -1,4 +1,4 @@
-# This configuration file contains the paths to the data files to be downloaded from NCBI to use in the pipeline.
+# This configuration file contains the paths to the NCBI data files needed by the SeqRepo/UTA load pipelines.
 #
 #    ├── gene
 #    │   └── DATA
@@ -20,3 +20,28 @@
 #                ├── human.1.protein.faa.gz
 #                ├── human.1.rna.fna.gz
 #                └── human.1.rna.gbff.gz
+
+## Gene Data
+gene/DATA/gene2refseq.gz
+gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
+
+## RefSeq Data
+refseq/H_sapiens/mRNA_Prot/human.*.rna.gbff.gz
+refseq/H_sapiens/mRNA_Prot/human.*.rna.fna.gz
+refseq/H_sapiens/mRNA_Prot/human.*.protein.faa.gz
+
+## Genome build and alignment data
+# Build 37
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_assembly_report.txt
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_genomic.fna.gz
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_genomic.gff.gz
+
+# Build 38
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_assembly_report.txt
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_genomic.fna.gz
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_genomic.gff.gz
+
+# T2Tv2.0
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_assembly_report.txt
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.fna.gz
+genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.gff.gz

--- a/etc/ncbi-files.txt
+++ b/etc/ncbi-files.txt
@@ -1,0 +1,22 @@
+# This configuration file contains the paths to the data files to be downloaded from NCBI to use in the pipeline.
+#
+#    ├── gene
+#    │   └── DATA
+#    │       ├── GENE_INFO
+#    │       │   └── Mammalia
+#    │       │       └── Homo_sapiens.gene_info.gz
+#    │       └── gene2accession.gz
+#    ├── genomes
+#    │   └── refseq
+#    │       └── vertebrate_mammalian
+#    │           └── Homo_sapiens
+#    │               └── all_assembly_versions
+#    │                   └── GCF_000001405.25_GRCh37.p13
+#    │                       ├── GCF_000001405.25_GRCh37.p13_genomic.fna.gz
+#    │                       └── GCF_000001405.25_GRCh37.p13_genomic.gff.gz
+#    └── refseq
+#        └── H_sapiens
+#            └── mRNA_Prot
+#                ├── human.1.protein.faa.gz
+#                ├── human.1.rna.fna.gz
+#                └── human.1.rna.gbff.gz

--- a/etc/ncbi-files.txt
+++ b/etc/ncbi-files.txt
@@ -41,6 +41,10 @@ genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_00000
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_genomic.fna.gz
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_genomic.gff.gz
 
+# RefSeq historical alignments
+# genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40-RS_2023_03_knownrefseq_alns.gff.gz
+# genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40-RS_2023_03_knownrefseq_rna.gbff.gz
+
 # T2Tv2.0
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_assembly_report.txt
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.fna.gz

--- a/etc/ncbi-files.txt
+++ b/etc/ncbi-files.txt
@@ -30,6 +30,10 @@ refseq/H_sapiens/mRNA_Prot/human.*.rna.gbff.gz
 refseq/H_sapiens/mRNA_Prot/human.*.rna.fna.gz
 refseq/H_sapiens/mRNA_Prot/human.*.protein.faa.gz
 
+## Historical RefSeq alignments
+refseq/H_sapiens/historical/GRCh38/GCF_000001405.40-RS_2023_03_historical/GCF_000001405.40-RS_2023_03_knownrefseq_alns.gff.gz
+refseq/H_sapiens/historical/GRCh38/GCF_000001405.40-RS_2023_03_historical/GCF_000001405.40-RS_2023_03_knownrefseq_rna.gbff.gz
+
 ## Genome build and alignment data
 # Build 37
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_assembly_report.txt
@@ -40,10 +44,6 @@ genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_00000
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_assembly_report.txt
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_genomic.fna.gz
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_genomic.gff.gz
-
-# RefSeq historical alignments
-# genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40-RS_2023_03_knownrefseq_alns.gff.gz
-# genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/GCF_000001405.40-RS_2023_03_knownrefseq_rna.gbff.gz
 
 # T2Tv2.0
 genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_assembly_report.txt

--- a/etc/ncbi-files.txt
+++ b/etc/ncbi-files.txt
@@ -16,10 +16,16 @@
 #    │                       └── GCF_000001405.25_GRCh37.p13_genomic.gff.gz
 #    └── refseq
 #        └── H_sapiens
+#            ├── historical
+#            │   └── GRCh38
+#            │       └── GCF_000001405.40-RS_2023_03_historical
+#            │           ├── GCF_000001405.40-RS_2023_03_knownrefseq_alns.gff.gz
+#            │           └── GCF_000001405.40-RS_2023_03_knownrefseq_rna.gbff.gz
 #            └── mRNA_Prot
 #                ├── human.1.protein.faa.gz
 #                ├── human.1.rna.fna.gz
-#                └── human.1.rna.gbff.gz
+#                ├── human.1.rna.gbff.gz
+#                ├── ...
 
 ## Gene Data
 gene/DATA/gene2refseq.gz

--- a/sbin/ncbi-download
+++ b/sbin/ncbi-download
@@ -2,7 +2,7 @@
 
 # This script downloads the files needed for a UTA+SeqRepo update into to the given directory.
 #
-# DONWLOAD_DIR will have the following structure:
+# DOWNLOAD_DIR will have the following structure:
 #
 #    ├── gene
 #    │   └── DATA

--- a/sbin/ncbi-download
+++ b/sbin/ncbi-download
@@ -2,48 +2,22 @@
 
 # This script downloads the files needed for a UTA+SeqRepo update into to the given directory.
 #
-# DOWNLOAD_DIR will have the following structure:
-#
-#    ├── gene
-#    │   └── DATA
-#    │       ├── GENE_INFO
-#    │       │   └── Mammalia
-#    │       │       └── Homo_sapiens.gene_info.gz
-#    │       └── gene2accession.gz
-#    ├── genomes
-#    │   └── refseq
-#    │       └── vertebrate_mammalian
-#    │           └── Homo_sapiens
-#    │               └── all_assembly_versions
-#    │                   └── GCF_000001405.25_GRCh37.p13
-#    │                       ├── GCF_000001405.25_GRCh37.p13_genomic.fna.gz
-#    │                       └── GCF_000001405.25_GRCh37.p13_genomic.gff.gz
-#    └── refseq
-#        └── H_sapiens
-#            └── mRNA_Prot
-#                ├── human.1.protein.faa.gz
-#                ├── human.1.rna.fna.gz
-#                └── human.1.rna.gbff.gz
+# DESTINATION_DIR will have a directory structure matching the source.
 
 set -e
 
-DOWNLOAD_DIR=$1
-DOWNLOAD_PATHS=(
-    'gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz'
-    'gene/DATA/gene2accession.gz'
-    'refseq/H_sapiens/mRNA_Prot/human.*.rna.gbff.gz'
-)
+FILE_PATH_CONFIG=$1
+DOWNLOAD_DIR=$2
 
-if [ -z "$DOWNLOAD_DIR" ]
+if [ -z "$FILE_PATH_CONFIG" ] || [ -z "$DOWNLOAD_DIR" ]
 then
-    echo 'Usage: sbin/ncbi-download <download_dir>'
+    echo 'Usage: sbin/ncbi-download <file path config> <download_dir> '
     exit 1
 else
     echo "Downloading files to $DOWNLOAD_DIR"
 fi
 
-for DOWNLOAD_PATH in "${DOWNLOAD_PATHS[@]}"
-do
+grep -v -e '^#' -e '^$' "$FILE_PATH_CONFIG" | while read -r DOWNLOAD_PATH; do
     # each top-level directory in NCBI is an rsync module.
     # bash parameter expansion removes all content after first slash.
     DOWNLOAD_MODULE="${DOWNLOAD_PATH%%/*}"


### PR DESCRIPTION
This PR:

- Moves the paths to needed NCBI files to it's own config
- Added the missing files and other genome builds
- Updates download-ncbi script to pull paths from config file
- Updates docker-compose.yml to pass config file parameter

To test these changes I performed the following...
```
docker build --target uta -t uta-update .

mkdir ncbi

export UTA_ETL_NCBI_DIR=./ncbi

docker compose run ncbi-download
```

docker compose output...
```
Downloading files to /ncbi-dir
Downloading ftp.ncbi.nlm.nih.gov::gene/DATA/gene2refseq.gz to /ncbi-dir/gene
receiving incremental file list
DATA/
DATA/gene2refseq.gz
  1,700,651,030 100%   12.73MB/s    0:02:07 (xfr#1, to-chk=0/2)

sent 51 bytes  received 1,701,066,362 bytes  13,034,991.67 bytes/sec
total size is 1,700,651,030  speedup is 1.00
Downloading ftp.ncbi.nlm.nih.gov::gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz to /ncbi-dir/gene
receiving incremental file list
DATA/
DATA/GENE_INFO/
DATA/GENE_INFO/Mammalia/
DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
      5,120,527 100%    4.81MB/s    0:00:01 (xfr#1, to-chk=0/4)

sent 59 bytes  received 5,121,994 bytes  1,138,234.00 bytes/sec
total size is 5,120,527  speedup is 1.00
...
```

The resulting output took 8.8Gb of disk space and in the output directory had the following structure...
```
sgiles-MD6M:uta shane.giles$ tree ncbi
ncbi
├── gene
│   └── DATA
│       ├── GENE_INFO
│       │   └── Mammalia
│       │       └── Homo_sapiens.gene_info.gz
│       └── gene2refseq.gz
├── genomes
│   └── refseq
│       └── vertebrate_mammalian
│           └── Homo_sapiens
│               └── all_assembly_versions
│                   ├── GCF_000001405.25_GRCh37.p13
│                   │   ├── GCF_000001405.25_GRCh37.p13_assembly_report.txt
│                   │   ├── GCF_000001405.25_GRCh37.p13_genomic.fna.gz
│                   │   └── GCF_000001405.25_GRCh37.p13_genomic.gff.gz
│                   ├── GCF_000001405.40_GRCh38.p14
│                   │   ├── GCF_000001405.40_GRCh38.p14_assembly_report.txt
│                   │   ├── GCF_000001405.40_GRCh38.p14_genomic.fna.gz
│                   │   └── GCF_000001405.40_GRCh38.p14_genomic.gff.gz
│                   └── GCF_009914755.1_T2T-CHM13v2.0
│                       ├── GCF_009914755.1_T2T-CHM13v2.0_assembly_report.txt
│                       ├── GCF_009914755.1_T2T-CHM13v2.0_genomic.fna.gz
│                       └── GCF_009914755.1_T2T-CHM13v2.0_genomic.gff.gz
└── refseq
    └── H_sapiens
        └── mRNA_Prot
            ├── human.1.protein.faa.gz
            ├── human.1.rna.fna.gz
            ├── human.1.rna.gbff.gz
            ├── human.10.protein.faa.gz
            ├── human.10.rna.fna.gz
            ├── human.10.rna.gbff.gz
            ├── human.11.protein.faa.gz
            ├── human.11.rna.fna.gz
            ├── human.11.rna.gbff.gz
...
```
**UPDATE**
I verified that if a file is not found by rsync, the script exits with an error code.
```
Downloading ftp.ncbi.nlm.nih.gov::genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/RefSeq_historical_alignments/GCF_000001405.40-RS_2023_03_knownrefseq_alns.gff.gz to /ncbi-dir/genomes
receiving incremental file list
rsync: link_stat "/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.40_GRCh38.p14/RefSeq_historical_alignments/GCF_000001405.40-RS_2023_03_knownrefseq_alns.gff.gz" (in genomes) failed: No such file or directory (2)

sent 8 bytes  received 262 bytes  108.00 bytes/sec
total size is 0  speedup is 0.00
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1865) [Receiver=3.2.7]
```