### PR TITLE
IPVC-2344: Update SeqRepo load to discover local fasta files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04 as uta
 ARG python_version="3.10"
 
 # list and install dependencies
-ARG dependencies="python${python_version} python3-dev python3-pip rsync git postgresql-client-14"
+ARG dependencies="python${python_version} python3-dev python3-pip rsync git postgresql-client-14 tabix"
 
 RUN apt-get update && apt-get install -y $dependencies && apt-get clean
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
     network_mode: host
   seqrepo-load:
     image: uta-update
-    command: sbin/seqrepo-load /usr/local/share/seqrepo 2024-02-20 /seqrepo-load/work /seqrepo-load/logs
+    command: sbin/seqrepo-load /usr/local/share/seqrepo ${UTA_ETL_OLD_SEQREPO_VERSION} /seqrepo-load/input /seqrepo-load/logs
     volumes:
       - ${UTA_ETL_SEQREPO_DIR}:/usr/local/share/seqrepo
-      - ${UTA_ETL_WORK_DIR}:/seqrepo-load/work
+      - ${UTA_ETL_NCBI_DIR}:/seqrepo-load/input
       - ${UTA_ETL_LOG_DIR}:/seqrepo-load/logs
     working_dir: /opt/repos/uta
     network_mode: host
@@ -62,7 +62,7 @@ services:
     network_mode: host
   splign-manual:
     image: uta-update
-    command: sbin/uta-splign-manual 2024-02-20 ${UTA_ETL_OLD_UTA_VERSION} /uta-splign-manual/input /uta-splign-manual/work /uta-splign-manual/logs
+    command: sbin/uta-splign-manual ${UTA_ETL_OLD_SEQREPO_VERSION} ${UTA_ETL_OLD_UTA_VERSION} /uta-splign-manual/input /uta-splign-manual/work /uta-splign-manual/logs
     depends_on:
       uta:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
     network_mode: host
   seqrepo-load:
     image: uta-update
-    command: sbin/seqrepo-load /usr/local/share/seqrepo ${UTA_ETL_OLD_SEQREPO_VERSION} /seqrepo-load/input /seqrepo-load/logs
+    command: sbin/seqrepo-load /usr/local/share/seqrepo ${UTA_ETL_OLD_SEQREPO_VERSION} /seqrepo-load/work /seqrepo-load/logs
     volumes:
       - ${UTA_ETL_SEQREPO_DIR}:/usr/local/share/seqrepo
-      - ${UTA_ETL_NCBI_DIR}:/seqrepo-load/input
+      - ${UTA_ETL_WORK_DIR}:/seqrepo-load/work
       - ${UTA_ETL_LOG_DIR}:/seqrepo-load/logs
     working_dir: /opt/repos/uta
     network_mode: host

--- a/sbin/seqrepo-load
+++ b/sbin/seqrepo-load
@@ -13,9 +13,9 @@ then
     exit 1
 fi
 
+fasta_files=$(find /seqrepo-load/input -type f -name "*.f[an]a.gz" -printf "%p ")
+
 ## Load SeqRepo with new sequences
 seqrepo --root-directory "$seqrepo_root" \
     load -n NCBI --instance-name "$seqrepo_version" \
-    $sequence_dir/*.fna.gz \
-    $sequence_dir/*.faa.gz 2>& 1 | \
-    tee "$log_dir/seqrepo-load.log"
+    $fasta_files 2>& 1 | tee "$log_dir/seqrepo-load.log"

--- a/sbin/seqrepo-load
+++ b/sbin/seqrepo-load
@@ -13,9 +13,9 @@ then
     exit 1
 fi
 
-fasta_files=$(find /seqrepo-load/input -type f -name "*.f[an]a.gz" -printf "%p ")
-
 ## Load SeqRepo with new sequences
 seqrepo --root-directory "$seqrepo_root" \
     load -n NCBI --instance-name "$seqrepo_version" \
-    $fasta_files 2>& 1 | tee "$log_dir/seqrepo-load.log"
+    "$sequence_dir"/*.fna.gz \
+    "$sequence_dir"/*.faa.gz 2>& 1 | \
+    tee "$log_dir/seqrepo-load.log"

--- a/sbin/uta-extract
+++ b/sbin/uta-extract
@@ -36,3 +36,6 @@ sbin/ncbi_parse_genomic_gff.py "$GFF_files" | gzip -c > "$working_dir/unfiltered
 sbin/filter_exonset_transcripts.py --tx-info "$working_dir/txinfo.gz" --exonsets "$working_dir/unfiltered_exonsets.gz" \
     --missing-ids "$working_dir/filtered_tx_acs.txt" | gzip -c > "$working_dir/exonsets.gz" 2>&1 | \
     tee "$log_dir/filter_exonset_transcripts.log"
+
+# move fasta files into same dir
+find "$ncbi_dir" -type f -name "*.f[an]a.gz" -print0 | xargs -i --null cp {} "$working_dir/"

--- a/sbin/uta-extract
+++ b/sbin/uta-extract
@@ -36,8 +36,3 @@ sbin/ncbi_parse_genomic_gff.py "$GFF_files" | gzip -c > "$working_dir/unfiltered
 sbin/filter_exonset_transcripts.py --tx-info "$working_dir/txinfo.gz" --exonsets "$working_dir/unfiltered_exonsets.gz" \
     --missing-ids "$working_dir/filtered_tx_acs.txt" | gzip -c > "$working_dir/exonsets.gz" 2>&1 | \
     tee "$log_dir/filter_exonset_transcripts.log"
-
-# move fasta files into same dir
-cp -f $ncbi_dir/refseq/H_sapiens/mRNA_Prot/human.*.rna.fna.gz $working_dir/
-cp -f $ncbi_dir/refseq/H_sapiens/mRNA_Prot/human.*.protein.faa.gz $working_dir/
-cp -f $ncbi_dir/genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405*/GCF_*_genomic.fna.gz $working_dir/


### PR DESCRIPTION
This PR adds logic to the `sbin/uta-extract` script to discover fasta files rather then have them hardcoded. Those files will be copied into a single working directory.

During testing of this work I found an issue with our Docker image. It did not have `tabix` installed and thus could not add sequences to SeqRepo. So the dockerfile was updated to include it.

To test I ran the following...
```
sgiles-MD6M:uta shane.giles$ docker compose run uta-extract
WARN[0000] The "UTA_ETL_SKIP_GENE_LOAD" variable is not set. Defaulting to a blank string.
/opt/repos/uta/sbin/ncbi-parse-gbff:33: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
2024-04-24 17:57:08 INFO     [__main__] opened /ncbi-dir/refseq/H_sapiens/mRNA_Prot/human.test.rna.gbff.gz
/usr/local/lib/python3.10/dist-packages/Bio/GenBank/Scanner.py:1217: BiopythonParserWarning: Premature end of file in sequence data
  warnings.warn(
2024-04-24 17:59:19 INFO     [__main__] 642 genes in /ncbi-dir/refseq/H_sapiens/mRNA_Prot/human.test.rna.gbff.gz (Counter({'NM': 1384, 'NR': 380}))
2024-04-24 17:59:19 INFO     [__main__] 642 genes in 1 files (Counter({'NM': 1384, 'NR': 380}))
/opt/repos/uta/sbin/ncbi_parse_genomic_gff.py:33: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
2024-04-24 17:59:20 INFO     [__main__] read 1776 transcript alignments from file(s): /ncbi-dir/genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_genomic.gff.gz
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NM_000853.3 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NR_003491.3 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NR_033319.2 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NR_033320.2 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NR_033321.2 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NR_156186.2 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NM_001284286.1 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NM_001284289.1 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NM_001284288.1 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NM_001002837.2 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NM_001284287.1 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 WARNING  [__main__] Exon set transcript NM_001350317.2 not found in txinfo file. Filtering out.
2024-04-24 17:59:21 INFO     [__main__] Filtered out exon sets for 12 transcript(s): NM_001350317.2,NR_003491.3,NM_001002837.2,NM_000853.3,NR_033320.2,NM_001284289.1,NR_033319.2,NM_001284287.1,NR_033321.2,NM_001284288.1,NR_156186.2,NM_001284286.1
```
Verified the fasta files were copied to the working directory
```
sgiles-MD6M:uta shane.giles$ cd output/artifacts/
sgiles-MD6M:artifacts shane.giles$ ll
total 29224
-rw-r--r--  1 shane.giles  staff  11122313 Apr 24 11:59 GCF_000001405.25_GRCh37.p13_genomic.fna.gz
-rw-r--r--  1 shane.giles  staff    307826 Apr 24 11:59 GCF_000001405.25_GRCh37.p13_protein.faa.gz
-rw-r--r--  1 shane.giles  staff   1330779 Apr 24 11:59 GCF_000001405.25_GRCh37.p13_rna.fna.gz
-rw-r--r--  1 shane.giles  staff     19252 Apr 24 11:57 assocacs.gz
-rw-r--r--  1 shane.giles  staff     60177 Apr 24 11:59 exonsets.gz
-rw-r--r--  1 shane.giles  staff       174 Apr 24 11:59 filtered_tx_acs.txt
-rw-r--r--  1 shane.giles  staff     33216 Apr 24 11:57 geneinfo.gz
-rw-r--r--  1 shane.giles  staff    301989 Apr 24 11:59 human.test.protein.faa.gz
-rw-r--r--  1 shane.giles  staff   1623010 Apr 24 11:59 human.test.rna.fna.gz
drwxr-xr-x  7 shane.giles  staff       224 Apr 17 16:35 splign-manual
-rw-r--r--  1 shane.giles  staff     79638 Apr 24 11:59 txinfo.gz
-rw-r--r--  1 shane.giles  staff     60481 Apr 24 11:59 unfiltered_exonsets.gz
```
Then I was able to successfully run `seqrepo-load`
```
sgiles-MD6M:uta shane.giles$ docker compose run seqrepo-load
WARN[0000] The "UTA_ETL_SKIP_GENE_LOAD" variable is not set. Defaulting to a blank string.
human.test.protein.faa.gz: 100%|██████████| 5/5 [00:20<00:00,  4.17s/file]
```