### PR TITLE
feat(IPVC-2408): Mito processing updates and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,14 +347,14 @@ See 2A for nuclear transcripts and 2B for mitochondrial transcripts.
 docker compose run ncbi-download
 docker compose run uta-extract
 docker compose run seqrepo-load
-UTA_ETL_SKIP_GENE_LOAD=false docker compose run uta-load
+docker compose run uta-load
 ```
 
 #### 2B. Mitochondrial transcripts
 ```
 docker compose run mito-extract
 docker compose run seqrepo-load
-UTA_ETL_SKIP_GENE_LOAD=true docker compose run uta-load
+docker compose run uta-load
 ```
 
 #### 2C. Manual splign transcripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     network_mode: host
   uta-load:
     image: uta-update
-    command: sbin/uta-load ${UTA_ETL_OLD_UTA_VERSION} /ncbi-dir /uta-load/work /uta-load/logs ${UTA_ETL_SKIP_GENE_LOAD}
+    command: sbin/uta-load ${UTA_ETL_OLD_UTA_VERSION} /ncbi-dir /uta-load/work /uta-load/logs
     depends_on:
       uta:
         condition: service_healthy

--- a/sbin/seqrepo-load
+++ b/sbin/seqrepo-load
@@ -13,9 +13,11 @@ then
     exit 1
 fi
 
-## Load SeqRepo with new sequences
+# find all fasta files in the working directory
+mapfile -t FASTA_FILES < <(find "$sequence_dir" -type f -name "*.f[an]a*")
+
+# Load SeqRepo with new sequences
 seqrepo --root-directory "$seqrepo_root" \
     load -n NCBI --instance-name "$seqrepo_version" \
-    "$sequence_dir"/*.fna.gz \
-    "$sequence_dir"/*.faa.gz 2>& 1 | \
+    "${FASTA_FILES[@]}" 2>& 1 | \
     tee "$log_dir/seqrepo-load.log"

--- a/sbin/uta-diff
+++ b/sbin/uta-diff
@@ -15,6 +15,7 @@ cmp_cols.update({
     "associated_accessions": "tx_ac pro_ac origin".split(),
     "exon_aln": "exon_aln_id tx_exon_id alt_exon_id cigar added".split(),
     "gene": "gene_id".split(),
+    "seq_anno": "seq_anno_id seq_id origin_id ac added".split(),
     "transcript": "ac".split(),
     })
 
@@ -41,7 +42,7 @@ def cmp1(con, tbl, s1, s2):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger()
 
     url = "postgresql://uta_admin@localhost/uta"

--- a/sbin/uta-extract
+++ b/sbin/uta-extract
@@ -37,5 +37,9 @@ sbin/filter_exonset_transcripts.py --tx-info "$working_dir/txinfo.gz" --exonsets
     --missing-ids "$working_dir/filtered_tx_acs.txt" | gzip -c > "$working_dir/exonsets.gz" 2>&1 | \
     tee "$log_dir/filter_exonset_transcripts.log"
 
+# generate seqinfo files from exonsets (this step requires seqrepo)
+sbin/exonset-to-seqinfo -o NCBI "$working_dir/exonsets.gz" | gzip -c > "$working_dir/seqinfo.gz" 2>&1 | \
+    tee "$log_dir/exonset-to-seqinfo.log"
+
 # move fasta files into same dir
 find "$ncbi_dir" -type f -name "*.f[an]a.gz" -print0 | xargs -i --null cp {} "$working_dir/"

--- a/sbin/uta-extract
+++ b/sbin/uta-extract
@@ -37,9 +37,5 @@ sbin/filter_exonset_transcripts.py --tx-info "$working_dir/txinfo.gz" --exonsets
     --missing-ids "$working_dir/filtered_tx_acs.txt" | gzip -c > "$working_dir/exonsets.gz" 2>&1 | \
     tee "$log_dir/filter_exonset_transcripts.log"
 
-# generate seqinfo files from exonsets (this step requires seqrepo)
-sbin/exonset-to-seqinfo -o NCBI "$working_dir/exonsets.gz" | gzip -c > "$working_dir/seqinfo.gz" 2>&1 | \
-    tee "$log_dir/exonset-to-seqinfo.log"
-
 # move fasta files into same dir
 find "$ncbi_dir" -type f -name "*.f[an]a.gz" -print0 | xargs -i --null cp {} "$working_dir/"

--- a/sbin/uta-load
+++ b/sbin/uta-load
@@ -32,6 +32,10 @@ etc/scripts/create-new-schema.sh "$source_uta_v" "$loading_uta_v"
 ## for now set up Alembic for schema migrations
 alembic -c etc/alembic.ini upgrade head
 
+# generate seqinfo files from exonsets (this step requires seqrepo)
+sbin/exonset-to-seqinfo -o NCBI "$working_dir/exonsets.gz" | gzip -c > "$working_dir/seqinfo.gz" 2>&1 | \
+    tee "$log_dir/exonset-to-seqinfo.log"
+
 # Filter out columns from assocacs file.
 sbin/assoc-acs-merge "$working_dir/assocacs.gz" | gzip -c > "$working_dir/assoc-ac.gz" 2>&1 | \
     tee "$log_dir/assoc-acs-merge.log"

--- a/sbin/uta-load
+++ b/sbin/uta-load
@@ -5,7 +5,6 @@
 # ncbi_dir is where the script looks for NCBI data files.
 # working_dir stores intermediate data files and the final database dump.
 # log_dir stores log files.
-# skip_load_genes, if truthy, will skip the gene loading step
 
 # Note that the uta loading code uses the seqrepo location defined in the conf files, under [sequences].seqrepo.
 
@@ -15,7 +14,6 @@ source_uta_v=$1
 ncbi_dir=$2
 working_dir=$3
 log_dir=$4
-skip_load_genes=$5
 
 if [ -z "$source_uta_v" ] || [ -z "$ncbi_dir" ] || [ -z "$working_dir" ] || [ -z "$log_dir" ]
 then
@@ -34,22 +32,13 @@ etc/scripts/create-new-schema.sh "$source_uta_v" "$loading_uta_v"
 ## for now set up Alembic for schema migrations
 alembic -c etc/alembic.ini upgrade head
 
-# generate seqinfo files from exonsets (this step requires seqrepo)
-sbin/exonset-to-seqinfo -o NCBI "$working_dir/exonsets.gz" | gzip -c > "$working_dir/seqinfo.gz" 2>&1 | \
-    tee "$log_dir/exonset-to-seqinfo.log"
-
 # Filter out columns from assocacs file.
 sbin/assoc-acs-merge "$working_dir/assocacs.gz" | gzip -c > "$working_dir/assoc-ac.gz" 2>&1 | \
     tee "$log_dir/assoc-acs-merge.log"
 
 # Load genes into gene table.
-if [ "$skip_load_genes" = "true" ]
-then
-    echo "Skipping load-geneinfo"
-else
-    uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf load-geneinfo "$working_dir/geneinfo.gz" 2>&1 | \
-        tee "$log_dir/load-geneinfo.log"
-fi
+uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf load-geneinfo "$working_dir/geneinfo.gz" 2>&1 | \
+    tee "$log_dir/load-geneinfo.log"
 
 # Load accessions into associated_accessions table.
 uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf load-assoc-ac "$working_dir/assoc-ac.gz" 2>&1 | \
@@ -73,6 +62,3 @@ uta --conf=etc/global.conf --conf=etc/uta_dev@localhost.conf align-exons 2>&1 | 
 
 ### run diff
 sbin/uta-diff "$source_uta_v" "$loading_uta_v"
-
-### psql_dump
-pg_dump -U uta_admin -h localhost -d uta -t "$loading_uta_v.gene" | gzip -c > "$working_dir/uta.pgd.gz"

--- a/src/uta/loading.py
+++ b/src/uta/loading.py
@@ -523,6 +523,7 @@ def load_seqinfo(session, opts, cf):
                     session.merge(u_seqanno)
             else:
                 # create the new annotation
+                logger.debug("creating seq_anno({si.origin},{si.ac},{si.md5})".format(si=si))
                 u_seqanno = usam.SeqAnno(origin_id=u_ori.origin_id, seq_id=si.md5,
                                          ac=si.ac, descr=si.descr)
                 session.add(u_seqanno)
@@ -533,6 +534,7 @@ def load_seqinfo(session, opts, cf):
             logger.info("{n_created} annotations created/{i_md5} sequences seen ({p:.1f}%)/{n_rows} sequences total".format(
                 n_created=n_created, i_md5=i_md5, n_rows=n_rows, md5=md5, p=i_md5 / n_rows * 100))
             session.commit()
+    session.commit()
 
 
 def load_sequences(session, opts, cf):


### PR DESCRIPTION
This ticket was originally meant to revert any logic to the `ncbi_process_mito.py` script that added bases to the end of the "placeholder" transcripts to handle incomplete stop codons. With the changes from IPVC-2390 and the addition of the `translation_exception` table, we no longer need to modify these sequences. Turns out that we did not add this logic yet, so there was nothing to do. During the testing of this ticket several issues were discovered (or rediscovered) and fixed:

- Added logic to the `ncbi_process_mito.py` script to create a geneinfo.gz file. With this change we will no longer need the `UTA_ETL_SKIP_GENE_LOAD ` variable. This change allows us to run workflows in the order we choose.
- The seqrepo load step was not finding all fasta files. It only would find those that end in gz. It was not loading the mito reference downloaded from NCBI (`NC_012920.1.fna`).
- The `uta-diff` to ignore changes in the `descr` field as differences.
- In the uta loading module, additions to `seq` and `seq_anno` from the `seqinfo` file are committed in batches. But there is no commit on the last partial batch. This was causing the mito sequences to be missing from UTA. See the diff below before and after the change. Interestingly the sequences were already added to UTA as ENSTs.

BEFORE
```
+-----------------------+------+---------+---------+-----+---------+-----+------------------------------------------------+
|         table         |  t   |    n1   |    n2   | nu1 |    nc   | nu2 |                      cols                      |
+-----------------------+------+---------+---------+-----+---------+-----+------------------------------------------------+
| associated_accessions | 6.9  |  265035 |  265048 |  0  |  265035 |  13 |              tx_ac,pro_ac,origin               |
|          exon         | 39.6 | 8310936 | 8311010 |  0  | 8310936 |  74 |                       *                        |
|        exon_aln       | 27.8 | 5604190 | 5604227 |  0  | 5604190 |  37 | exon_aln_id,tx_exon_id,alt_exon_id,cigar,added |
|        exon_set       | 5.5  |  894082 |  894156 |  0  |  894082 |  74 |                       *                        |
|          gene         | 0.2  |  64055  |  64092  |  0  |  64055  |  37 |                    gene_id                     |
|          meta         | 0.0  |    4    |    4    |  0  |    4    |  0  |                       *                        |
|         origin        | 0.0  |    6    |    6    |  0  |    6    |  0  |                       *                        |
|          seq          | 20.8 |  340384 |  340384 |  0  |  340384 |  0  |                       *                        |
|        seq_anno       | 4.7  |  360063 |  360064 |  0  |  360063 |  1  |                       *                        |
|       transcript      | 11.5 |  314227 |  314264 |  0  |  314227 |  37 |                       ac                       |
+-----------------------+------+---------+---------+-----+---------+-----+------------------------------------------------+
```

AFTER
```
+-----------------------+------+---------+---------+-----+---------+-----+------------------------------------------------+
|         table         |  t   |    n1   |    n2   | nu1 |    nc   | nu2 |                      cols                      |
+-----------------------+------+---------+---------+-----+---------+-----+------------------------------------------------+
| associated_accessions | 7.2  |  265035 |  265048 |  0  |  265035 |  13 |              tx_ac,pro_ac,origin               |
|          exon         | 41.2 | 8310936 | 8311010 |  0  | 8310936 |  74 |                       *                        |
|        exon_aln       | 31.2 | 5604190 | 5604227 |  0  | 5604190 |  37 | exon_aln_id,tx_exon_id,alt_exon_id,cigar,added |
|        exon_set       | 6.1  |  894082 |  894156 |  0  |  894082 |  74 |                       *                        |
|          gene         | 0.2  |  64055  |  64092  |  0  |  64055  |  37 |                    gene_id                     |
|          meta         | 0.0  |    4    |    4    |  0  |    4    |  0  |                       *                        |
|         origin        | 0.0  |    6    |    6    |  0  |    6    |  0  |                       *                        |
|          seq          | 19.4 |  340384 |  340384 |  0  |  340384 |  0  |                       *                        |
|        seq_anno       | 2.4  |  360063 |  360100 |  0  |  360063 |  37 |     seq_anno_id,seq_id,origin_id,ac,added      |
|       transcript      | 10.2 |  314227 |  314264 |  0  |  314227 |  37 |                       ac                       |
+-----------------------+------+---------+---------+-----+---------+-----+------------------------------------------------+
```