### PR TITLE
feat(IPVC-2425): add migration to fix tx-alt-exon-pairs view

### DIFF
--- a/src/alembic/versions/f885cb84efce_update_tx_alt_exon_pairs_v.py
+++ b/src/alembic/versions/f885cb84efce_update_tx_alt_exon_pairs_v.py
@@ -30,7 +30,7 @@ def upgrade() -> None:
                     FROM exon_SET tes
                     JOIN transcript t ON tes.tx_ac=t.ac
                     JOIN gene g ON t.gene_id=g.gene_id
-                    JOIN exon_set aes ON tes.tx_ac=aes.tx_ac AND tes.alt_aln_method='transcript' AND aes.alt_aln_method NOT LIKE 'transcript%'
+                    JOIN exon_set aes ON tes.tx_ac=aes.tx_ac AND tes.alt_aln_method='transcript' AND aes.alt_aln_method !~ 'transcript'
                     JOIN exon tex ON tes.exon_SET_id=tex.exon_SET_id
                     JOIN exon aex ON aes.exon_SET_id=aex.exon_SET_id AND tex.ORD=aex.ORD
                     LEFT JOIN exon_aln ea ON ea.tx_exon_id=tex.exon_id AND ea.alt_exon_id=AEX.exon_id;

--- a/src/alembic/versions/f885cb84efce_update_tx_alt_exon_pairs_v.py
+++ b/src/alembic/versions/f885cb84efce_update_tx_alt_exon_pairs_v.py
@@ -1,0 +1,57 @@
+"""update tx_alt_exon_pairs_v
+
+Revision ID: f885cb84efce
+Revises: 14eed54ff90d
+Create Date: 2024-05-07 21:01:03.693969
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f885cb84efce'
+down_revision: Union[str, None] = '14eed54ff90d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS tx_alt_exon_pairs_v CASCADE;")
+    op.execute("""
+                CREATE VIEW tx_alt_exon_pairs_v AS
+                    SELECT g.symbol, g.symbol as hgnc, g.gene_id,TES.exon_SET_id AS tes_exon_SET_id,
+                       AES.exon_SET_id AS aes_exon_SET_id, TES.tx_ac AS tx_ac,AES.alt_ac AS alt_ac,
+                       AES.alt_strand,AES.alt_aln_method, TEX.ORD AS ORD,TEX.exon_id AS tx_exon_id,
+                       AEX.exon_id AS alt_exon_id, TEX.start_i AS tx_start_i,TEX.END_i AS tx_END_i, 
+                       AEX.start_i AS alt_start_i, AEX.END_i AS alt_END_i, EA.exon_aln_id,EA.cigar
+                    FROM exon_SET tes
+                    JOIN transcript t ON tes.tx_ac=t.ac
+                    JOIN gene g ON t.gene_id=g.gene_id
+                    JOIN exon_set aes ON tes.tx_ac=aes.tx_ac AND tes.alt_aln_method='transcript' AND aes.alt_aln_method NOT LIKE 'transcript%'
+                    JOIN exon tex ON tes.exon_SET_id=tex.exon_SET_id
+                    JOIN exon aex ON aes.exon_SET_id=aex.exon_SET_id AND tex.ORD=aex.ORD
+                    LEFT JOIN exon_aln ea ON ea.tx_exon_id=tex.exon_id AND ea.alt_exon_id=AEX.exon_id;
+            """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS tx_alt_exon_pairs_v CASCADE;")
+    op.execute("""
+                CREATE VIEW tx_alt_exon_pairs_v AS
+                    SELECT g.symbol, g.symbol as hgnc, g.gene_id,TES.exon_SET_id AS tes_exon_SET_id,
+                       AES.exon_SET_id AS aes_exon_SET_id, TES.tx_ac AS tx_ac,AES.alt_ac AS alt_ac,
+                       AES.alt_strand,AES.alt_aln_method, TEX.ORD AS ORD,TEX.exon_id AS tx_exon_id,
+                       AEX.exon_id AS alt_exon_id, TEX.start_i AS tx_start_i,TEX.END_i AS tx_END_i, 
+                       AEX.start_i AS alt_start_i, AEX.END_i AS alt_END_i, EA.exon_aln_id,EA.cigar
+                    FROM exon_SET tes
+                    JOIN transcript t ON tes.tx_ac=t.ac
+                    JOIN gene g ON t.gene_id=g.gene_id
+                    JOIN exon_set aes ON tes.tx_ac=aes.tx_ac AND tes.alt_aln_method='transcript' AND aes.alt_aln_method!='transcript'
+                    JOIN exon tex ON tes.exon_SET_id=tex.exon_SET_id
+                    JOIN exon aex ON aes.exon_SET_id=aex.exon_SET_id AND tex.ORD=aex.ORD
+                    LEFT JOIN exon_aln ea ON ea.tx_exon_id=tex.exon_id AND ea.alt_exon_id=AEX.exon_id;
+            """)
+


### PR DESCRIPTION
This PR addresses an existing issue with a view in the UTA database, `tx_alt_exon_pairs_v`. This view is used to find transcript and alternate accession exon pairs for the `align-exons` method. The goal is to find valid pairs that are missing CIGAR stings provided by `uta-align`.

The query finds transcript exons with the `alt_aln_method="transcript"` and alignments with `alt_aln_method !="transcript"`. An issue is encountered when we deprecate an existing transcript. This happens when the cds start/end has changed or the exon structure has changed. UTA does not delete the old record, nor does it update the cds or exon values. It updates the alt_aln_method so that it is essentially hidden. Here is an example of an exon set record being updated due to a change in the exon definition of the transcript.

`Transcript: exon_set_id: 343991; tx_ac: NM_001173991.2; alt_aln_method: transcript`

was updated to...

`Transcript: exon_set_id: 343991; tx_ac: NM_001173991.2; alt_aln_method: transcript/70b44909`

because the exon structure went from `0,306;306,408;408,501;501,702;702,1306` -> `0,306;306,408;408,501;501,703;703,1306`

using the following query you will see that the updated (deprecated) transcript exon set is showing up as alt_aln_methods that will be passed to `align_exons`. There is no need to align transcript exons from one deprecated structure to the latest. This issue can be addressed by adjusting the WHERE criteria of the view.

`alt_aln_method !="transcript"` -> `alt_aln_method !~ "transcript"`

To test this I ran the following query pre and post Alembic migration.
```
select a.symbol, a.gene_id, a.tx_ac, a.alt_ac, a.alt_aln_method, count(a.ord) as exon_cnt
from (
      -- query from uta.loading.align_exons, filters for exon pairs missing an exon
      --   alignment and transcripts containing a "/" character.
      select *
      from uta.tx_alt_exon_pairs_v as v
      where exon_aln_id is NULL and tx_ac !~ '/'
) as a
where a.tx_ac='NM_001173991.2'
group by a.symbol, a.gene_id, a.tx_ac, a.alt_ac, a.alt_aln_method;
```

BEFORE:
```
+-------+-------+--------------+--------------+-------------------+--------+
|symbol |gene_id|tx_ac         |alt_ac        |alt_aln_method     |exon_cnt|
+-------+-------+--------------+--------------+-------------------+--------+
|TMEM216|51259  |NM_001173991.2|AC_000143.1   |splign             |5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.10  |splign             |5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.10  |splign/d0e7701b    |5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.9   |blat               |5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.9   |splign             |5       |
|TMEM216|51259  |NM_001173991.2|NC_018922.2   |splign             |5       |
|TMEM216|51259  |NM_001173991.2|NG_032976.1   |splign             |5       |
|TMEM216|51259  |NM_001173991.2|NM_001173991.2|transcript/6bcc9051|5       |
|TMEM216|51259  |NM_001173991.2|NM_001173991.2|transcript/70b44909|5       |
+-------+-------+--------------+--------------+-------------------+--------+
```

AFTER:
```
+-------+-------+--------------+------------+---------------+--------+
|symbol |gene_id|tx_ac         |alt_ac      |alt_aln_method |exon_cnt|
+-------+-------+--------------+------------+---------------+--------+
|TMEM216|51259  |NM_001173991.2|AC_000143.1 |splign         |5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.10|splign         |5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.10|splign/d0e7701b|5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.9 |blat           |5       |
|TMEM216|51259  |NM_001173991.2|NC_000011.9 |splign         |5       |
|TMEM216|51259  |NM_001173991.2|NC_018922.2 |splign         |5       |
|TMEM216|51259  |NM_001173991.2|NG_032976.1 |splign         |5       |
+-------+-------+--------------+------------+---------------+--------+

```

