### PR TITLE
feat(IPVC-2422): add migration to create materialized view for tx_exon_aln_v

### DIFF
--- a/src/alembic/versions/19561fe444c8_create_materialized_view_for_tx_exon_.py
+++ b/src/alembic/versions/19561fe444c8_create_materialized_view_for_tx_exon_.py
@@ -1,0 +1,32 @@
+"""create materialized view for tx_exon_aln_v
+
+Revision ID: 19561fe444c8
+Revises: f885cb84efce
+Create Date: 2024-05-07 21:59:09.078549
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '19561fe444c8'
+down_revision: Union[str, None] = 'f885cb84efce'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS tx_exon_aln_mv CASCADE;")
+    op.execute("""
+            CREATE MATERIALIZED VIEW tx_exon_aln_mv AS SELECT * FROM tx_exon_aln_v WITH NO DATA;
+            CREATE INDEX tx_exon_aln_mv_tx_alt_ac_ix ON tx_exon_aln_mv(tx_ac, alt_ac, alt_aln_method);
+            GRANT SELECT ON tx_exon_set_summary_mv TO public;
+            REFRESH MATERIALIZED VIEW tx_exon_aln_mv;
+        """)
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS tx_exon_aln_mv CASCADE;")


### PR DESCRIPTION
There has been performance testing issues on new database infrastructure show large differences in query time using the `tx_exon_aln_v` view. This is a very common query ran for HGVS. It is defined in the UTA dataprovider [here](https://github.com/biocommons/hgvs/blob/main/src/hgvs/dataproviders/uta.py#L137).
```
        "tx_exons": """
            select *
            from tx_exon_aln_v
            where tx_ac=? and alt_ac=? and alt_aln_method=?
            order by alt_start_i
            """,
```
There has been talking of modifying the query, creating new indexes, etc. Since this is such a common query I wanted to see if creating a Materialized view for it was feasible and would increase performance. This PR introduces an Alembic migration that will create the materialized view and a multi column index matching the criteria of the query above. I did some local testing and the new materialized view does show a performance improvement. It will be really interesting to get this on a RDS server to test there to see how different it is.

The performance test selects 10,000 tx_ac, alt_ac at random, constructs the same query as above using the view or materialized view, and records the timings. 
```
INFO  [alembic.runtime.migration] Running upgrade f885cb84efce -> 19561fe444c8, create materialized view for tx_exon_aln_v
root@lima-rancher-desktop:/opt/repos/uta# python misc/test_view_timing.py
INFO:test_view_timings:Connection to UTA database postgresql://uta_admin@localhost/uta
INFO:uta:connected to postgresql://uta_admin@localhost/uta
INFO:test_view_timings:Retrieving transcript and exon set data
INFO:test_view_timings:Processed 1001 queries against tx_exon_aln_v: average speed 0.007 s
INFO:test_view_timings:Processed 2001 queries against tx_exon_aln_v: average speed 0.006 s
INFO:test_view_timings:Processed 3001 queries against tx_exon_aln_v: average speed 0.006 s
INFO:test_view_timings:Processed 4001 queries against tx_exon_aln_v: average speed 0.005 s
INFO:test_view_timings:Processed 5001 queries against tx_exon_aln_v: average speed 0.005 s
INFO:test_view_timings:Processed 6001 queries against tx_exon_aln_v: average speed 0.005 s
INFO:test_view_timings:Processed 7001 queries against tx_exon_aln_v: average speed 0.005 s
INFO:test_view_timings:Processed 8001 queries against tx_exon_aln_v: average speed 0.004 s
INFO:test_view_timings:Processed 9001 queries against tx_exon_aln_v: average speed 0.004 s
INFO:test_view_timings:Processed 1001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 2001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 3001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 4001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 5001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 6001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 7001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 8001 queries against tx_exon_aln_mv: average speed 0.001 s
INFO:test_view_timings:Processed 9001 queries against tx_exon_aln_mv: average speed 0.001 s
```
