### PR TITLE
feat(IPVC-2435): add chromosome reference accession to unique alignme…

### DIFF
--- a/sbin/ncbi_parse_genomic_gff.py
+++ b/sbin/ncbi_parse_genomic_gff.py
@@ -45,6 +45,10 @@ class GFFRecord:
     parent_id: str
     transcript_id: str
 
+    @property
+    def key(self) -> str:
+        return f"{self.transcript_id}:{self.seqid}"
+
 
 def _sort_exons(exons: List[GFFRecord]) -> List[GFFRecord]:
     return sorted(exons, key=lambda e: e.exon_number)
@@ -115,7 +119,7 @@ def parse_gff_files(file_paths: List[str]) -> dict[str, List[GFFRecord]]:
                 except ValueError as e:
                     raise Exception(f"Failed at line :{line} with error: {e}")
                 if record:
-                    tx_data[record.parent_id].append(record)
+                    tx_data[record.key].append(record)
     return {k: _sort_exons(v) for k, v in tx_data.items()}
 
 


### PR DESCRIPTION
As written the `ncbi_parse_genomic_gff.py` will have issues if we run a UTA build and pass it GFF files from multiple builds. Because the same transcript should have alignments in multiple builds. It uses the `parent_id` as a key to group exon alignments together. And example of that key is here: `Parent=rna-NR_046018.2`. If we add a reference accession to the key, which are unique across genome builds, this will work. This PR updates the key used to group alignments and updates tests to verify the fix.