### PR TITLE
feat(IPVC-2441): various workflow fixes

### DIFF
--- a/etc/ncbi-files.txt
+++ b/etc/ncbi-files.txt
@@ -5,7 +5,7 @@
 #    │       ├── GENE_INFO
 #    │       │   └── Mammalia
 #    │       │       └── Homo_sapiens.gene_info.gz
-#    │       └── gene2accession.gz
+#    │       └── gene2refseq.gz
 #    ├── genomes
 #    │   └── refseq
 #    │       └── vertebrate_mammalian

--- a/sbin/seqrepo-load
+++ b/sbin/seqrepo-load
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euxo pipefail
 
 seqrepo_root=$1
 seqrepo_version=$2
@@ -19,5 +19,5 @@ mapfile -t FASTA_FILES < <(find "$sequence_dir" -type f -name "*.f[an]a*")
 # Load SeqRepo with new sequences
 seqrepo --root-directory "$seqrepo_root" \
     load -n NCBI --instance-name "$seqrepo_version" \
-    "${FASTA_FILES[@]}" 2>& 1 | \
+    "${FASTA_FILES[@]}" 2>&1 | \
     tee "$log_dir/seqrepo-load.log"

--- a/sbin/uta-extract
+++ b/sbin/uta-extract
@@ -2,7 +2,7 @@
 
 # Extract data from NCBI files into intermediate files.
 
-set -e
+set -euxo pipefail
 
 ncbi_dir=$1
 working_dir=$2
@@ -19,12 +19,12 @@ sbin/ncbi-parse-geneinfo $ncbi_dir/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gen
     gzip -c > "$working_dir/geneinfo.gz" 2>&1 | tee "$log_dir/ncbi-parse-geneinfo.log"
 
 # transcript protein associations
-sbin/ncbi-parse-gene2refseq $ncbi_dir/gene/DATA/gene2accession.gz | gzip -c > "$working_dir/assocacs.gz" 2>&1 | \
+sbin/ncbi-parse-gene2refseq $ncbi_dir/gene/DATA/gene2refseq.gz | gzip -c > "$working_dir/assocacs.gz" 2>&1 | \
     tee "$log_dir/ncbi-fetch-assoc-acs.log"
 
 # parse transcript info from GBFF input files
-GBFF_files=$(ls $ncbi_dir/refseq/H_sapiens/mRNA_Prot/human.*.rna.gbff.gz)
-sbin/ncbi-parse-gbff "$GBFF_files" | gzip -c > "$working_dir/txinfo.gz" 2>&1 | \
+mapfile -t GBFF_FILES < <(find "$ncbi_dir/refseq" -type f -name "human.*.rna.gbff.gz")
+sbin/ncbi-parse-gbff "${GBFF_FILES[@]}" | gzip -c > "$working_dir/txinfo.gz" 2>&1 | \
     tee "$log_dir/ncbi-parse-gbff.log"
 
 # parse alignments from GFF input files

--- a/src/uta/exceptions.py
+++ b/src/uta/exceptions.py
@@ -22,6 +22,10 @@ class EutilsDownloadError(Exception):
     pass
 
 
+class ExonStructureMismatchError(UTAError):
+    pass
+
+
 # <LICENSE>
 # Copyright 2014 UTA Contributors (https://bitbucket.org/biocommons/uta)
 ##


### PR DESCRIPTION
This PR is addressing several issues discovered during the latest full test run:

1. Storing the results of the `ls` command into a variable that is quoted to pass multiple files to a command does not work well.
2. The `sbin/uta-extract` script was setup to use `gene2accessions` instead of `gene2refseq` to parse associated accessions from. This is a mistake as decided to use `gene2refseq` since it is a strict subset of `gene2accessions` for RefSeq sequences.
3. There is a type in `sbin/seqrepo-load`:  on line 22 `"${FASTA_FILES[@]}" 2>& 1 | \`.
4. There are some transcripts that are not being loaded, due to missing exon definitions. Perhaps these should have been filtered out before this step, but they were not. This caused an exception during the loading of exonsets, as we assume the transcript will be present.
5. During the full load we did find one transcript where the gene id was updated. We did not think this would happen, seems like we were a little too optimistic. This is an allowable change.