### PR TITLE
feat(IPVC-2478): updates/fixes to UTA files found during testing

### DIFF
--- a/etc/uta_dev@uic.com
+++ b/etc/uta_dev@uic.com
@@ -1,4 +1,4 @@
 [uta]
-hostport = uta.invitae.com
+hostport = uta-int-02.cj7o8ef9mt4v.us-east-1.rds.amazonaws.com
 user = uta_admin
-database = uta_dev
+database = uta

--- a/misc/export_mappings.py
+++ b/misc/export_mappings.py
@@ -65,7 +65,7 @@ where tx_ac='{}';
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Generate alignment metrics for transcript alignments"
+        description="Export transcript alignments for a given genome build from UTA database."
     )
     parser.add_argument("transcripts_file", type=str)
     parser.add_argument("--genome-build", type=str, default="GRCh37.p13")

--- a/misc/export_mappings.py
+++ b/misc/export_mappings.py
@@ -1,0 +1,184 @@
+import argparse
+import logging
+import re
+from bioutils.assemblies import make_name_ac_map
+from contextlib import ExitStack
+from dataclasses import dataclass, field
+
+import psycopg2
+import six
+
+import uta
+
+logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s', level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger("export_mappings")
+
+
+UTA_SCHEMA_VERSION_SQL = """
+select value as schema_version
+from meta
+where key='schema_version';
+"""
+
+ASSOCIATED_ACCESSIONS_SQL = """
+select aa.tx_ac, aa.pro_ac
+from associated_accessions as aa
+where aa.tx_ac='{}';
+"""
+
+# get_tx_mapping_options
+TX_MAPPING_OPTIONS_SQL = """
+select distinct tx_ac,alt_ac,alt_aln_method
+from tx_exon_aln_v where tx_ac='{}' and exon_aln_id is not NULL
+order by alt_ac,alt_aln_method;
+"""
+
+# get_tx_info
+TX_V1_INFO_SQL = """
+select hgnc, cds_start_i, cds_end_i, tx_ac, alt_ac, alt_aln_method
+from transcript T
+join exon_set ES on T.ac=ES.tx_ac
+where tx_ac='{}' and alt_ac='{}' and alt_aln_method='{}';
+"""
+
+TX_V2_INFO_SQL = """
+select G.hgnc, T.cds_start_i, T.cds_end_i, ES.tx_ac, ES.alt_ac, ES.alt_aln_method
+from gene G
+join transcript T on G.gene_id=T.gene_id
+join exon_set ES on T.ac=ES.tx_ac
+where tx_ac='{}' and alt_ac='{}' and alt_aln_method='{}';
+"""
+
+EXON_SET_SQL = """
+select *
+from tx_exon_aln_v
+where tx_ac='{}' and alt_ac='{}' and alt_aln_method='{}'
+order by alt_start_i;
+"""
+
+TX_INDENTITY_SQL = """
+select distinct(tx_ac), alt_ac, alt_aln_method, cds_start_i, cds_end_i, lengths, hgnc
+from tx_def_summary_v
+where tx_ac='{}';
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate alignment metrics for transcript alignments"
+    )
+    parser.add_argument("transcripts_file", type=str)
+    parser.add_argument("--genome-build", type=str, default="GRCh37.p13")
+    parser.add_argument("--db-url", default="postgresql://uta_admin@localhost/uta")
+    parser.add_argument("--schema-name", default="uta_20210129")
+    return parser.parse_args()
+
+
+def _get_cursor(con, schema_name):
+    cur = con.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
+    cur.execute(f"set search_path = {schema_name}")
+    return cur
+
+
+def _get_rows(cur, sql):
+    cur.execute(sql)
+    return cur.fetchall()
+
+
+def _get_chr_ac_map(genome_build):
+    filtered_chr_ac_map = {}
+
+    def_name_ac_map = make_name_ac_map(assy_name=genome_build, primary_only=True)
+    for chr_name in list(map(str, range(1, 23))) + ["X", "Y"]:
+        filtered_chr_ac_map[chr_name] = def_name_ac_map.get(chr_name)
+
+    return filtered_chr_ac_map
+
+
+def main(transcripts_file, genome_build, db_url, schema_name):
+    logger.info(f"connecting to {db_url}")
+    session = uta.connect(db_url)
+
+    con = session.bind.pool.connect()
+    cur = _get_cursor(con, schema_name)
+
+    chr_to_acc_dict = _get_chr_ac_map(genome_build=genome_build)
+
+    schema_version = _get_rows(cur, UTA_SCHEMA_VERSION_SQL)[0].schema_version
+    if schema_version == "1.1":
+        TX_INFO_SQL = TX_V1_INFO_SQL
+    else:
+        TX_INFO_SQL = TX_V2_INFO_SQL
+
+    # read in transcripts
+    transcripts = []
+    with open(transcripts_file, "r") as f:
+        for line in f:
+            if line.startswith("accession"):
+                continue
+            accession, chrom = line.rstrip("\r\n").split("\t")
+            transcripts.append((accession, chrom))
+
+    # setup context managers for file writers
+    with ExitStack() as stack:
+        # associated acccessions
+        assocacs_fh = stack.enter_context(
+            open(f"{schema_name}_associated_accessions.tsv", "w")
+        )
+        assocacs_fh.write("tx_ac\tpro_ac\n")
+
+        # transcript info
+        txinfo_fh = stack.enter_context(open(f"{schema_name}_transcript_info.tsv", "w"))
+        txinfo_fh.write("hgnc\ttx_ac\tcds_start_i\tcds_end_i\talt_ac\talt_aln_method\n")
+
+        # exon sets
+        exons_fh = stack.enter_context(open(f"{schema_name}_exon_sets.tsv", "w"))
+        exons_fh.write("hgnc\ttx_ac\talt_ac\talt_aln_method\talt_strand\tords\ttx_ac_se_i\talt_ac_se_i\tcigars\n")
+
+        # transcript identity
+        tx_identity_fh = stack.enter_context(
+            open(f"{schema_name}_transcript_identity.tsv", "w")
+        )
+
+        logger.info("querying database for transcript mappings...")
+        for i, (tx_ac, chrom) in enumerate(transcripts):
+            assocacs_rows = _get_rows(cur, ASSOCIATED_ACCESSIONS_SQL.format(tx_ac))
+            for row in assocacs_rows:
+                assocacs_fh.write(f"{row.tx_ac}\t{row.pro_ac}\n")
+
+            alt_ac = chr_to_acc_dict.get(chrom)
+            for alt_aln_method in ("splign", "splign-manual"):
+                txinfo_rows = _get_rows(
+                    cur, TX_INFO_SQL.format(tx_ac, alt_ac, alt_aln_method)
+                )
+                if txinfo_rows:
+                    for row in txinfo_rows:
+                        txinfo_fh.write(
+                            f"{row.hgnc}\t{row.tx_ac}\t{row.cds_start_i}\t{row.cds_end_i}\t{row.alt_ac}\t{row.alt_aln_method}\n"
+                        )
+                exons_rows = _get_rows(
+                    cur, EXON_SET_SQL.format(tx_ac, alt_ac, alt_aln_method)
+                )
+                if exons_rows:
+                    hgnc = exons_rows[0].hgnc
+                    tx_ac = exons_rows[0].tx_ac
+                    alt_ac = exons_rows[0].alt_ac
+                    alt_aln_method = exons_rows[0].alt_aln_method
+                    alt_strand = exons_rows[0].alt_strand
+                    ords, tx_ac_se_i, alt_ac_se_i, cigars = [], [], [], []
+                    for row in sorted(exons_rows, key=lambda x: x.ord):
+                        ords.append(str(row.ord))
+                        tx_ac_se_i.append(f"{row.tx_start_i},{row.tx_end_i}")
+                        alt_ac_se_i.append(f"{row.alt_start_i},{row.alt_end_i}")
+                        cigars.append(row.cigar)
+                    exons_fh.write(
+                        f"{hgnc}\t{tx_ac}\t{alt_ac}\t{alt_aln_method}\t{alt_strand}\t{';'.join(ords)}\t{';'.join(tx_ac_se_i)}\t{';'.join(alt_ac_se_i)}\t{';'.join(cigars)}\n"
+                    )
+
+            if i % 2500 == 0 and i > 0:
+                logger.info(f"processed {i} transcripts")
+
+
+if __name__ == '__main__':
+    arguments = parse_args()
+    main(arguments.transcripts_file, arguments.genome_build, arguments.db_url, arguments.schema_name)

--- a/misc/generate_alignment_metrics.py
+++ b/misc/generate_alignment_metrics.py
@@ -179,7 +179,7 @@ MM = "X"
 
 TX_EXON_SET_SUMMARY_ALL_BUILD37_SQL = """
 select *
-from uta_20210129b.tx_exon_set_summary_mv as mv
+from tx_exon_set_summary_mv as mv
 where mv.alt_aln_method in ('splign', 'splign-manual') and mv.tx_ac ~ 'N[MR]_*' and mv.tx_ac !~ '/'
       and mv.alt_ac in ('NC_000001.10', 'NC_000002.11', 'NC_000003.11', 'NC_000004.11', 'NC_000005.9', 'NC_000006.11',
                         'NC_000007.13', 'NC_000008.10', 'NC_000009.11', 'NC_000010.10', 'NC_000011.9', 'NC_000012.11',
@@ -190,14 +190,14 @@ where mv.alt_aln_method in ('splign', 'splign-manual') and mv.tx_ac ~ 'N[MR]_*' 
 
 TX_EXON_SET_SUMMARY_SQL = """
 select mv.ends_i[mv.n_exons] as tx_length, *
-from uta_20210129b.tx_exon_set_summary_mv as mv
+from tx_exon_set_summary_mv as mv
 where mv.tx_ac='{tx_ac}' and mv.alt_ac='{alt_ac}' and mv.alt_aln_method='{alt_aln_method}';
 """
 
 TX_EXON_ALN_SQL = """
 select v.hgnc, v.tx_ac, v.alt_ac, v.alt_aln_method, v.alt_strand, v.ord, v.tx_start_i, v.tx_end_i,
        v.alt_start_i, v.alt_end_i, v.cigar
-from uta_20210129b.tx_exon_aln_v as v
+from tx_exon_aln_v as v
 where tx_ac='{tx_ac}' and alt_ac='{alt_ac}' and alt_aln_method='{alt_aln_method}'
 order by ord;
 """
@@ -213,7 +213,6 @@ def parse_args():
 
 def _get_cursor(con, schema_name):
     cur = con.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
-    cur.execute("set role uta_admin;")
     cur.execute(f"set search_path = {schema_name}")
     return cur
 

--- a/misc/refseq-historical-backfill/ncbi_extract_gbff.py
+++ b/misc/refseq-historical-backfill/ncbi_extract_gbff.py
@@ -132,6 +132,7 @@ def main(gbff_files: Iterable, origin: str, prefix: str, output_dir: str) -> Non
                             gene_symbol=srf.gene_symbol,
                             cds_se_i=TxInfo.serialize_cds_se_i(srf.cds_se_i),
                             exons_se_i=TxInfo.serialize_exons_se_i(srf.exons_se_i),
+                            codon_table=srf.codon_table,
                             transl_except=TxInfo.serialize_transl_except(
                                 srf.transl_except
                             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
   "psycopg2-binary",
   "pytz",
   "recordtype",
+  "retry",
   "sqlalchemy",
   "uta-align>=0.3",
 ]

--- a/sbin/ncbi-parse-gbff
+++ b/sbin/ncbi-parse-gbff
@@ -118,6 +118,7 @@ if __name__ == "__main__":
                 gene_symbol=srf.gene_symbol,
                 cds_se_i=TxInfo.serialize_cds_se_i(srf.cds_se_i),
                 exons_se_i=TxInfo.serialize_exons_se_i(srf.exons_se_i),
+                codon_table=srf.codon_table,
                 transl_except=TxInfo.serialize_transl_except(srf.transl_except),
             )
             tiw.write(ti)

--- a/sbin/update-ncbi
+++ b/sbin/update-ncbi
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger()
 
-    url = "postgresql://uta_admin@localhost/uta_dev"
+    url = "postgresql://uta_admin@localhost/uta"
     uta, ncbi = sys.argv[1:3]
     conn = psycopg2.connect(url)
 

--- a/src/alembic/versions/edadb97f6502_initial_state.py
+++ b/src/alembic/versions/edadb97f6502_initial_state.py
@@ -300,6 +300,9 @@ def upgrade() -> None:
         CREATE MATERIALIZED VIEW tx_def_summary_mv AS SELECT * FROM tx_def_summary_dv WITH NO DATA;
     """)
     op.execute("""
+        CREATE VIEW tx_def_summary_v AS SELECT * FROM tx_def_summary_mv;
+    """)
+    op.execute("""
         COMMENT ON MATERIALIZED VIEW tx_def_summary_mv IS 'transcript definitions, with exon structures and fingerprints';
     """)
     op.execute("""
@@ -341,6 +344,7 @@ def downgrade() -> None:
     op.execute("DROP INDEX tx_def_summary_mv_alt_aln_method CASCADE")
     op.execute("DROP INDEX tx_def_summary_mv_alt_ac CASCADE")
     op.execute("DROP INDEX tx_def_summary_mv_tx_ac CASCADE")
+    op.execute("DROP VIEW tx_def_summary_v CASCADE;")
     op.execute("DROP MATERIALIZED VIEW tx_def_summary_mv CASCADE;")
     op.execute("DROP VIEW tx_def_summary_dv CASCADE;")
     op.execute("DROP MATERIALIZED VIEW tx_exon_set_summary_mv CASCADE;")

--- a/src/alembic/versions/f85dd97bd9f5_set_gene_id_and_primary_and_foreign_keys.py
+++ b/src/alembic/versions/f85dd97bd9f5_set_gene_id_and_primary_and_foreign_keys.py
@@ -154,6 +154,7 @@ def upgrade() -> None:
         CREATE VIEW tx_similarity_v AS
         SELECT DISTINCT
                D1.tx_ac as tx_ac1, D2.tx_ac as tx_ac2,
+               D1.hgnc = D2.hgnc as hgnc_eq,
                D1.symbol = D2.symbol as symbol_eq,
                D1.cds_md5=D2.cds_md5 as cds_eq,
                D1.es_fingerprint=D2.es_fingerprint as es_fp_eq,

--- a/src/uta/loading.py
+++ b/src/uta/loading.py
@@ -873,8 +873,7 @@ def refresh_matviews(session, opts, cf):
         "refresh materialized view exon_set_exons_fp_mv",
         "refresh materialized view tx_exon_set_summary_mv",
         "refresh materialized view tx_def_summary_mv",
-        # "refresh materialized view tx_aln_cigar_mv",
-        # "refresh materialized view tx_aln_summary_mv",
+        "refresh materialized view tx_exon_aln_mv",
     ]
 
     for cmd in cmds:


### PR DESCRIPTION
During the final build and testing of the UTA data release several issues were found and fixed...

1. Update methods that write out txinfo to add in the new codon_table column (`misc/refseq-historical-backfill/ncbi_extract_gbff.py` & `sbin/ncbi-parse-gbff`).
2. Fix uic config to point at Invitae internal server
3. Add `misc/export_mappings.py` to repo. Used to compare content from new version to the last.
4. Remove schema version and set role command from `misc/generate_alingment_metrics.py`.
5. Update data name in `sbin/update_ncbi` script.
6. Add `tx_def_summary_v` to initial alembic script.
7. Add `hgnc` to the `tx_similarity_v` view.
8. Add `tx_exon_aln_mv` to the `refresh_matviews` command.
